### PR TITLE
FBE: Use of recommended delete connection endpoint over delete permission endpoint

### DIFF
--- a/includes/API.php
+++ b/includes/API.php
@@ -250,18 +250,17 @@ class API extends Base {
 
 
 	/**
-	 * Deletes user API permission.
+	 * Deletes FBE/MBE connection API.
 	 *
 	 * This is their form of "revoke".
 	 *
-	 * @param string $user_id user ID. Defaults to the currently authenticated user
-	 * @param string $permission permission to delete
-	 * @return API\Response|API\User\Permissions\Delete\Response
+	 * @param string $external_business_id external business ID
+	 * @return API\Response|API\FBE\Installation\Delete\Response
 	 * @throws ApiException
 	 */
-	public function delete_user_permission( string $user_id, string $permission ): API\User\Permissions\Delete\Response {
-		$request = new API\User\Permissions\Delete\Request( $user_id, $permission );
-		$this->set_response_handler( API\User\Permissions\Delete\Response::class );
+	public function delete_mbe_connection( string $external_business_id): API\FBE\Installation\Delete\Response {
+		$request = new API\FBE\Installation\Delete\Request( $external_business_id);
+		$this->set_response_handler( API\FBE\Installation\Delete\Response::class );
 		return $this->perform_request( $request );
 	}
 

--- a/includes/API/FBE/Installation/Delete/Request.php
+++ b/includes/API/FBE/Installation/Delete/Request.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace WooCommerce\Facebook\API\FBE\Installation\Delete;
+
+defined( 'ABSPATH' ) || exit;
+
+use WooCommerce\Facebook\API\FBE\Installation;
+
+/**
+ * FBE installation API read request object.
+ *
+ * @since 2.0.0
+ */
+class Request extends Installation\Request {
+	/**
+	 * API request constructor.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param string $external_business_id external business_id
+	 */
+	public function __construct( $external_business_id ) {
+		// include the business ID in the request body
+		parent::__construct( 'fbe_installs', 'DELETE' );
+		$this->data['fbe_external_business_id'] = $external_business_id;
+	}
+}

--- a/includes/API/FBE/Installation/Delete/Response.php
+++ b/includes/API/FBE/Installation/Delete/Response.php
@@ -1,0 +1,13 @@
+<?php
+declare( strict_types=1 );
+
+namespace WooCommerce\Facebook\API\FBE\Installation\Delete;
+
+defined( 'ABSPATH' ) || exit;
+
+use WooCommerce\Facebook\API;
+
+/**
+ * FBE Installation API read response object.
+ */
+class Response extends API\Response {}

--- a/includes/Admin/Settings_Screens/Connection.php
+++ b/includes/Admin/Settings_Screens/Connection.php
@@ -281,11 +281,7 @@ class Connection extends Abstract_Settings_Screen {
 
 				<?php if ( $is_connected ) : ?>
 
-					<a href="<?php echo esc_url( facebook_for_woocommerce()->get_connection_handler()->get_manage_url() ); ?>" class="button button-primary">
-						<?php esc_html_e( 'Manage Connection', 'facebook-for-woocommerce' ); ?>
-					</a>
-
-					<a href="<?php echo esc_url( facebook_for_woocommerce()->get_connection_handler()->get_disconnect_url() ); ?>" class="uninstall">
+					<a href="<?php echo esc_url( facebook_for_woocommerce()->get_connection_handler()->get_disconnect_url() ); ?>" class="button button-primary uninstall">
 						<?php esc_html_e( 'Disconnect', 'facebook-for-woocommerce' ); ?>
 					</a>
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -390,12 +390,10 @@ class Connection {
 				$body = json_decode( $body, true );
 				if ( ! is_array( $body ) || empty( $body['data'] ) || 200 !== (int) wp_remote_retrieve_response_code( $response ) ) {
 					facebook_for_woocommerce()->log( print_r( $body, true ) );
-					throw new ApiException(
-						sprintf(wp_remote_retrieve_response_message( $response ))
-					);
+					throw new ApiException( (string) wp_remote_retrieve_response_message( $response ));
 				}
 			} else {
-				facebook_for_woocommerce()->log( 'User id not found for the disconnection procedure, connection will be reset.' );
+				facebook_for_woocommerce()->log( 'External business id not found for the disconnection procedure, connection will be reset.' );
 			}
 		} catch ( ApiException $exception ) {
 			facebook_for_woocommerce()->log( sprintf( 'An error occurred during disconnection: %s.', $exception->getMessage() ) );

--- a/tests/Unit/ApiTest.php
+++ b/tests/Unit/ApiTest.php
@@ -172,13 +172,13 @@ class ApiTest extends WP_UnitTestCase {
 	 * @return void
 	 * @throws ApiException In case of failed request.
 	 */
-	public function test_delete_user_permission_deletes_user_permission_request() {
-		$user_id    = '111189594891749';
-		$permission = 'manage_business_extension';
+	public function test_delete_mbe_connection_deletes_user_permission_request() {
+		$external_business_id = 'wordpress-facebook-62c3f1add134a';
 
-		$response = function( $result, $parsed_args, $url ) use ( $user_id, $permission ) {
+		$response = function( $result, $parsed_args, $url ) use ( $external_business_id ) {
 			$this->assertEquals( 'DELETE', $parsed_args['method'] );
-			$this->assertEquals( "{$this->endpoint}{$this->version}/{$user_id}/permissions/{$permission}", $url );
+			$this->assertEquals( "{$this->endpoint}{$this->version}/fbe_business/fbe_installs", $url );
+			$this->assertEquals( '{"fbe_external_business_id":"wordpress-facebook-62c3f1add134a"}', $parsed_args['body'] );
 			return [
 				'body'     => '{"success":true}',
 				'response' => [
@@ -189,7 +189,7 @@ class ApiTest extends WP_UnitTestCase {
 		};
 		add_filter( 'pre_http_request', $response, 10, 3 );
 
-		$response = $this->api->delete_user_permission( $user_id, $permission );
+		$response = $this->api->delete_mbe_connection( $external_business_id );
 
 		$this->assertTrue( $response->success );
 	}


### PR DESCRIPTION

### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Problem:**

1. The Delete Permission User API only removed Meta connection assets from the WooCommerce database, leaving asset-related data enabled on Meta surfaces.
2. If a user disconnected the connection before uninstalling assets from Meta surfaces using Managed Connection; the UI for Managed Connection was also removed, making it difficult for users to uninstall this feature from Meta surface.

**Solution:**

1. Replaced the Delete Permission User API with the recommended Delete FBE Connection endpoint, which uninstalls assets from Meta surfaces and removes their permissions.
2. Removed the Managed Connection UI button for uninstalling FBE from Meta surfaces, as the Delete Connection endpoint now handles this functionality.

### Screenshots:

<!--- Optional --->
**Before:**

<img width="784" alt="image" src="https://github.com/user-attachments/assets/76bf6364-2af8-4657-a043-8e79aaff99c6">

**After:**

<img width="803" alt="image" src="https://github.com/user-attachments/assets/45e7ebc8-4a74-4589-a9e3-0e4fff1f4f20">

<img width="797" alt="image" src="https://github.com/user-attachments/assets/f4d215b0-0959-4ee8-8347-16c64afe3460">



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Run new tests: `./vendor/bin/phpunit --filter test_delete_mbe_connection_deletes_user_permission_request`
2. Run all tests : `npm run test:php`
3. Lint: `./vendor/bin/phpcs`
4. Manual testing: I have tested new Disconnect UI flow; it uninstall FBE connection from WooCommerce as well as from Meta surface


### Changelog entry

- **Removed:** Delete Permission User API

- **Added:** Delete FBE Connection endpoint to uninstall assets from Meta surfaces and remove permissions

- **Removed:** Managed Connection UI button for uninstalling FBE from Meta surfaces (now handled by Delete Connection endpoint)
